### PR TITLE
Update dependencies and remove unnecessary ones.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,20 +16,12 @@
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/node": "^14.14.2",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-    "rollup": "^2.32.1",
+    "rollup": "^2.35.1",
     "tslib": "^2.0.3",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@types/pdfjs-dist": "^2.1.7",
     "canvas": "^2.6.1",
-    "fs": "^0.0.1-security",
-    "http": "^0.0.1-security",
-    "https": "^1.0.0",
-    "node-ensure": "^0.0.0",
-    "pdfjs-dist": "^2.6.347",
-    "url": "^0.11.0",
-    "webpack": "^5.18.0",
-    "zlib": "^1.0.5"
+    "pdfjs-dist": "^2.6.347"
   }
 }


### PR DESCRIPTION
I couldn't build the plugin at first, so I upgraded the dependency versions and removed as much as possible. I don't know what all the dependencies I removed where for, but now it works.