### PR TITLE
Add support to include ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Goal of this Plugin in to implement a native PDF handling workflow in Obsidian
 ### Features
 
 - Insert a single PDF Page inside Note
-- Insert a List of Pages into Obsidian Note
+- Insert a list or range of Pages into Obsidian Note
 - Hyperlink to PDF
 - Scale the size of PDF Pages to fit Note layout
 - Rotate PDF
@@ -20,7 +20,7 @@ Goal of this Plugin in to implement a native PDF handling workflow in Obsidian
 |parameter|required|example|
 |--|--|--|
 |url  |yes  |**myPDF.pdf** or **subfolder/myPDF.pdf** or "[[MyFile.pdf]]"
-|page|optional (default = 1)| **1** or **[1,6,7,8]**
+|page|optional (default = 1)| **1** or **[1, [3, 6], 8]** where **[3, 6]** is an inclusive range of pages
 |scale|optional (default = 1.0)| **0.5** for 50% size or **2.0** for 200% size
 |rotation|optional (default = 0)| **90** for 90deg or **-90** -90deg or **180**
 |rect|optional (default = \[0,0,0,0\])| offsetX, offsetY, sizeX, sizeX in Pixel

--- a/main.ts
+++ b/main.ts
@@ -4,7 +4,7 @@ import * as worker from "pdfjs-dist/build/pdf.worker.entry.js";
 
 interface PdfNodeParameters {
   url: string;
-  page: number | Array<number>;
+  page: number | Array<number | Array<number>>;
   scale: number;
   rotation: number;
   rect: Array<number>;
@@ -108,6 +108,17 @@ export default class BetterPDFPlugin extends Plugin {
     }
     if (parameters.page === undefined) {
       parameters.page = [1];
+    }
+
+    // Flatten ranges
+    for (let i = 0; i < parameters.page.length; i++) {
+      if (Array.isArray(parameters.page[i])) {
+        let range = parameters.page.splice(i, 1)[0] as Array<number>;
+        for (let j = range[0]; j <= range[1]; j++) {
+          parameters.page.splice(i, 0, j);
+          i += 1;
+        }
+      }
     }
 
     if (


### PR DESCRIPTION
This is based on #12 

With this, ranges of pages can be included by setting `"page": [[1, 10]]` (i.e. nested arrays).