### PR TITLE
Add option to auto scale pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ Goal of this Plugin in to implement a native PDF handling workflow in Obsidian
 |url  |yes  |**myPDF.pdf** or **subfolder/myPDF.pdf** or "[[MyFile.pdf]]"
 |page|optional (default = 1)| **1** or **[1,6,7,8]**
 |scale|optional (default = 1.0)| **0.5** for 50% size or **2.0** for 200% size
+|fit|optional (default = true)| **true** or **false**
 |rotation|optional (default = 0)| **90** for 90deg or **-90** -90deg or **180**
 |rect|optional (default = \[0,0,0,0\])| offsetX, offsetY, sizeX, sizeX in Pixel

--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ interface PdfNodeParameters {
   url: string;
   page: number | Array<number>;
   scale: number;
+  fit: boolean,
   rotation: number;
   rect: Array<number>;
 }
@@ -61,6 +62,10 @@ export default class BetterPDFPlugin extends Plugin {
 
             // Render Canvas
             var canvas = href.createEl("canvas");
+            if (parameters.fit) {
+              canvas.style.width = "100%";
+            }
+
             var context = canvas.getContext("2d");
 
             if (parameters.rect[2] < 1) {
@@ -116,6 +121,10 @@ export default class BetterPDFPlugin extends Plugin {
       parameters.scale > 10.0
     ) {
       parameters.scale = 1.0;
+    }
+
+    if (parameters.fit === undefined) {
+      parameters.fit = true;
     }
 
     if (parameters.rotation === undefined) {

--- a/package.json
+++ b/package.json
@@ -16,20 +16,12 @@
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/node": "^14.14.2",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-    "rollup": "^2.32.1",
+    "rollup": "^2.35.1",
     "tslib": "^2.0.3",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@types/pdfjs-dist": "^2.1.7",
     "canvas": "^2.6.1",
-    "fs": "^0.0.1-security",
-    "http": "^0.0.1-security",
-    "https": "^1.0.0",
-    "node-ensure": "^0.0.0",
-    "pdfjs-dist": "^2.6.347",
-    "url": "^0.11.0",
-    "webpack": "^5.18.0",
-    "zlib": "^1.0.5"
+    "pdfjs-dist": "^2.6.347"
   }
 }


### PR DESCRIPTION
This adds a new option `fit` which will rescale the canvas to always fit the view. It uses the canvas scaling, so the pages are only scaled, not redrawn in the proper resolution. I couldn't figure out how to do that, but this does work well enough for me.

This is also based on #12 