### PR TITLE
Make linking optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Goal of this Plugin in to implement a native PDF handling workflow in Obsidian
 |parameter|required|example|
 |--|--|--|
 |url  |yes  |**myPDF.pdf** or **subfolder/myPDF.pdf** or "[[MyFile.pdf]]"
+|link|optional (default = false)| **true** or **false**
 |page|optional (default = 1)| **1** or **[1,6,7,8]**
 |scale|optional (default = 1.0)| **0.5** for 50% size or **2.0** for 200% size
 |rotation|optional (default = 0)| **90** for 90deg or **-90** -90deg or **180**

--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,7 @@ import * as worker from "pdfjs-dist/build/pdf.worker.entry.js";
 
 interface PdfNodeParameters {
   url: string;
+  link: boolean;
   page: number | Array<number>;
   scale: number;
   rotation: number;
@@ -38,11 +39,16 @@ export default class BetterPDFPlugin extends Plugin {
           //Read pages
           for (let pageNumber of <number[]>parameters.page) {
             var page = await document.getPage(pageNumber);
+            var host = el;
 
             // Create hyperlink for Page
-            var href = el.createEl("a");
-            href.href = parameters.url + "#page=" + pageNumber;
-            href.className = "internal-link";
+            if (parameters.link) {
+              var href = el.createEl("a");
+              href.href = parameters.url + "#page=" + pageNumber;
+              href.className = "internal-link";
+
+              host = href;
+            }
 
             // Get Viewport
             var offsetX = Math.floor(
@@ -60,7 +66,7 @@ export default class BetterPDFPlugin extends Plugin {
             });
 
             // Render Canvas
-            var canvas = href.createEl("canvas");
+            var canvas = host.createEl("canvas");
             var context = canvas.getContext("2d");
 
             if (parameters.rect[2] < 1) {
@@ -100,6 +106,10 @@ export default class BetterPDFPlugin extends Plugin {
         parameters.url,
         ""
       ).path;
+    }
+
+    if (parameters.link === undefined) {
+      parameters.link = false;
     }
 
     //Convert Page to Array<Page>


### PR DESCRIPTION
This adds a new parameter to make linking configurable and kind of solves #3.

Currently, the default for this is `false`, but I intend to add a plugin settings page, where this can be configured.

(I could not find a way to selectively disable the preview for the pdf pages only)

Based on #12 