### PR TITLE
Add base scale multiplier to viewport based on actual canvas width

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -66,13 +66,6 @@ export default class BetterPDFPlugin extends Plugin {
 							parameters.rect[1] * -1 * parameters.scale
 						);
 
-						const viewport = page.getViewport({
-							scale: parameters.scale,
-							rotation: parameters.rotation,
-							offsetX: offsetX,
-							offsetY: offsetY,
-						});
-
 						// Render Canvas
 						const canvas = host.createEl("canvas");
 						if (parameters.fit) {
@@ -80,6 +73,16 @@ export default class BetterPDFPlugin extends Plugin {
 						}
 
 						const context = canvas.getContext("2d");
+
+						const baseViewportWidth = page.getViewport({scale: 1.0}).width;
+						const baseScale = canvas.clientWidth / baseViewportWidth;
+
+						const viewport = page.getViewport({
+							scale: baseScale * parameters.scale,
+							rotation: parameters.rotation,
+							offsetX: offsetX,
+							offsetY: offsetY,
+						});
 
 						if (parameters.rect[2] < 1) {
 							canvas.height = viewport.height;


### PR DESCRIPTION
Fix issue #20 where pdfs appear blurred because it's not scaled properly in pdf.js.

Pdf blur was from canvas/pdf size being smaller than the actual canvas rendered size. 

Tested only basic usage previewing pdfs at different window sizes. 