### PR TITLE
Add a fallback for client width calc

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -90,7 +90,7 @@ export default class BetterPDFPlugin extends Plugin {
 						const context = canvas.getContext("2d");
 
 						const baseViewportWidth = page.getViewport({scale: 1.0}).width;
-						const baseScale = canvas.clientWidth / baseViewportWidth;
+						const baseScale = canvas.clientWidth ? canvas.clientWidth / baseViewportWidth : 1;
 
 						const viewport = page.getViewport({
 							scale: baseScale * parameters.scale,


### PR DESCRIPTION
There are times when clientWidth would return 0 - when the object is not on the screen or not rendered for some other reason. This is a problem if a notebook is opened in Reading mode as you can't re-render the pdfs. 

Add a fallback to use a baseScale of 1 in these cases. 

An ideal solution would be to set the scaling post-document-load but not sure what would be the best way to do that. 

