### PR TITLE
Fix ReferenceError with Buffer object for iOS 

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -47,7 +47,7 @@ export default class BetterPDFPlugin extends Plugin {
 					}
 					//Read Document
 					const arrayBuffer = await this.app.vault.adapter.readBinary(parameters.url);
-					const buffer = Buffer.from(arrayBuffer);
+					const buffer = new Uint8Array(arrayBuffer);
 					const document = await pdfjs.getDocument(buffer).promise;
 
 					// page parameter as trigger for whole pdf, 0 = all pages


### PR DESCRIPTION
Use generic `Uint8Array` instead of the `Buffer` object. `Buffer` object raises a reference error and the base `Uint8Array` works well enough for the use case.
Tested locally. With the fix, I can view pdfs on my iPhone app.

Resolves #36 and #21 