### PR TITLE
Suggested LICENSE to allow new maintainers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Jaques22
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi, 
I've created this PR to add the MIT license to your repo as it would allow @joleaf  (or anyone else who wishes to fork this repo) to take over development of your plugin as it's no longer functional in Obsidian, see #46. 
Obsidian will not allow the [forked plugin](https://github.com/joleaf/obsidian-better-pdf-2-plugin) to be added to the official list since your original does not have any license, 
Please consider merging this (or adding another license that you'd prefer) to allow others to build on your work. Alternatively you could pull in their changes and allow the community to help you maintain your plugin which so many people have relied on.

I hope this does not come across rude as that's not how I intended it. Just trying to make it easier to get this plugin working again!